### PR TITLE
Fix method name in TaskList class

### DIFF
--- a/src/main/java/talkie/command/SortCommand.java
+++ b/src/main/java/talkie/command/SortCommand.java
@@ -17,7 +17,7 @@ public class SortCommand extends Command {
     public String execute(TaskList tasks, Ui ui, Storage storage) throws TalkieException {
 
         // Sort list of tasks
-        tasks.sortByDesciption();
+        tasks.sortByDescription();
         return ui.listSortedTasks(tasks);
     }
 

--- a/src/main/java/talkie/task/TaskList.java
+++ b/src/main/java/talkie/task/TaskList.java
@@ -87,7 +87,7 @@ public class TaskList {
         return this.tasks.isEmpty();
     }
 
-    public void sortByDesciption() {
+    public void sortByDescription() {
         Collections.sort(this.tasks, (t1, t2) -> t1.getDesc().compareToIgnoreCase(t2.getDesc()));
     }
 }


### PR DESCRIPTION
There was a typo in the sortByDescription() method. Initially it was named sortByDesciption. However, the intended name was sortByDescription, with a missing r.